### PR TITLE
Update: catch clone errors 

### DIFF
--- a/app/components/feed/feed.js
+++ b/app/components/feed/feed.js
@@ -24,12 +24,18 @@ export default ({ p2p }) => {
       const contentUrls = [
         ...new Set(profiles.map(profile => profile.rawJSON.contents).flat())
       ]
-      const contents = await Promise.all(
-        contentUrls.map(url => {
+
+      const contents = []
+      for (const url of contentUrls) {
+        try {
           const [key, version] = url.split('+')
-          return p2p.clone(encode(key), version)
-        })
-      )
+          const c = await p2p.clone(encode(key), version)
+          contents.push(c)
+        } catch (err) {
+          console.error(err)
+        }
+      }
+
       setContents(contents.flat().sort(sort))
     })()
   }, [])

--- a/app/components/feed/feed.js
+++ b/app/components/feed/feed.js
@@ -29,8 +29,8 @@ export default ({ p2p }) => {
       for (const url of contentUrls) {
         try {
           const [key, version] = url.split('+')
-          const c = await p2p.clone(encode(key), version)
-          contents.push(c)
+          const content = await p2p.clone(encode(key), version)
+          contents.push(content)
         } catch (err) {
           console.error(err)
         }


### PR DESCRIPTION
This PR is a little tweak that looks to populate the feed with some content and finish earlier. 

sdk `clone` method is prone to throw errors when content (`index.json`) is unreachable. This can be the case for specific version that are not shared at the moment, for example. 