### PR TITLE
Add messageBox for update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           windows_certs: ${{ secrets.windows_certs }}
           windows_certs_password: ${{ secrets.windows_certs_password }}
           release: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          args: -c.releaseInfo.releaseNotesFile=./release-notes.md
           max_attempts: 5
         env:
           API_KEY_ID: ${{ secrets.api_key_id }}

--- a/index.js
+++ b/index.js
@@ -229,7 +229,23 @@ const main = async () => {
   await app.whenReady()
   mainWindow = await createMainWindow()
   app.setAsDefaultProtocolClient('hypergraph')
-  if (app.isPackaged) autoUpdater.checkForUpdatesAndNotify()
+
+  if (app.isPackaged) autoUpdater.checkForUpdates()
+
+  autoUpdater.addListener('update-downloaded', info => {
+    const options = {
+      type: 'question',
+      buttons: ['Install'],
+      defaultId: 0,
+      title: 'Update Hypergraph',
+      message: info.releaseName,
+      detail: info.releaseNotes
+    }
+
+    dialog.showMessageBox(null, options, response => {
+      if (response === 0) autoUpdater.quitAndInstall()
+    })
+  })
 }
 
 main()

--- a/index.js
+++ b/index.js
@@ -230,6 +230,19 @@ const main = async () => {
   mainWindow = await createMainWindow()
   app.setAsDefaultProtocolClient('hypergraph')
 
+  const options = {
+    type: 'question',
+    buttons: ['Install'],
+    defaultId: 0,
+    title: 'Update Hypergraph',
+    message: 'null',
+    detail: null
+  }
+
+  dialog.showMessageBox(null, options, response => {
+    console.log(response)
+  })
+
   if (app.isPackaged) autoUpdater.checkForUpdates()
 
   autoUpdater.addListener('update-downloaded', info => {
@@ -238,7 +251,7 @@ const main = async () => {
       buttons: ['Install'],
       defaultId: 0,
       title: 'Update Hypergraph',
-      message: info.releaseName,
+      message: `Version ${info.releaseName}`,
       detail: info.releaseNotes
     }
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,0 +1,12 @@
+In this new version we added:
+
+* New content creation in menu bar
+* Link to the community chat menu bar
+
+We fixed:
+
+* Networking is more reliable
+
+We changed:
+
+* Design of the welcome tour

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,12 +1,12 @@
 In this new version we added:
 
-* New content creation in menu bar
-* Link to the community chat menu bar
+- New content creation in menu bar
+- Link to the community chat menu bar
 
 We fixed:
 
-* Networking is more reliable
+- Networking is more reliable
 
 We changed:
 
-* Design of the welcome tour
+- Design of the welcome tour


### PR DESCRIPTION
This changes the update procedure from `autoUpdater.checkForUpdatesAndNotify()` to a dialog box that displays the release name and changelog. For the event and what it returns, see the [`autoUpdater docs`](https://www.electronjs.org/docs/api/auto-updater#event-update-downloaded).﻿ 

This update dialog is more verbose than the system notification, which gives users information about what changes occur in the update. Note: Including a more approachable summary of the update is important for the release notes.

I've tested to the extent that I can, but cannot test this exact implementation for Hypergraph outside of production (due to code signing and release workflow of GitHub) --- I think. Open to suggestions on how to test this if at all possible. I am not 100% on what is returned by `info.releaseName` and `info.releaseNotes` (especially the latter; it's not populated directly but may be grabbed from the GitHub release, otherwise see [`electron-builder` docs](https://www.electron.build/configuration/configuration#metadata)), so it would be helpful to test this prior to merging.

Closes #320.